### PR TITLE
Add MinerXfellows in miners.md

### DIFF
--- a/MinerXfellows
+++ b/MinerXfellows
@@ -1,0 +1,1 @@
+Update Client list


### PR DESCRIPTION
Add the MinerX Fellows in FIL+ program.

## Description
The list of the fellows:
https://docs.google.com/spreadsheets/d/1cBU77GAvCaDfexj95JTMfBYYvyf2nX2b96BiEBirxUA/edit#gid=0

## Is this PR related with an open issue?
No. 

## Types of changes

- [ ] Adding minerx fellows to the miner registry (miners.md)
 
